### PR TITLE
Enrollment File Sorting

### DIFF
--- a/AvailityCSharpAssessment/AvailityAssessmentTest/EnrollmentFileFormatterTest.cs
+++ b/AvailityCSharpAssessment/AvailityAssessmentTest/EnrollmentFileFormatterTest.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AvailityCSharpAssessment;
+
+namespace AvailityAssessmentTest
+{
+    [TestClass]
+    public class EnrollmentFileFormatterTest
+    {
+    }
+}

--- a/AvailityCSharpAssessment/AvailityAssessmentTest/UtilitiesTest.cs
+++ b/AvailityCSharpAssessment/AvailityAssessmentTest/UtilitiesTest.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AvailityCSharpAssessment;
+using System.IO;
+using System.Collections.Generic;
+
+namespace AvailityAssessmentTest
+{
+    [TestClass]
+    public class UtilitiesTest
+    {
+        [TestMethod]
+        public void ReadCSVFile_Test()
+        {
+            string filePath = Directory.GetCurrentDirectory() + "\\TestEnrollment_NoDuplicates.csv";
+            List<string> expected = new List<string>()
+            {
+                "12459,Liam,Elsher,1,United Health",
+                "12460,Olivia,Solace,2,Kaiser Foundation",
+                "12461,Noah,Levine,3,Anthem Inc",
+                "12462,Emma,Thatcher,4,Centene Corporation",
+                "12463,Oliver,Raven,5,Humana",
+                "12464,Ava,Bardot,6,CVS",
+                "12465,Elijah,St. James,7,Health Care Service Corporation (HCSC)",
+                "12466,Charlotte,Hansley,8,CIGNA",
+                "12467,William,Cromwell,9,Molina Healthcare",
+                "12468,Sophia,Ashley,10,Independence Health Group",
+                "12469,James,Monroe,11,Guidewell Mutual Holding",
+                "12470,Amelia,West,12,California Physicians Service",
+                "12471,Benjamin,Langley,13,Highmark Group",
+                "12472,Isabella,Daughtler,14,Blue Cross Blue Shield of Michigan",
+                "12473,Lucas,Madison,15,Blue Cross of California",
+                "12474,Mia,Marley,16,Blue Cross Blue Shield of New Jersey",
+                "12475,Henry,Ellis,17,Caresource",
+                "12476,Evelyn,Hope,18,UPMC Health System",
+                "12477,Alexander,Cassidy,19,Health Net of California",
+            };
+
+            List<string> actual = Utilities.ReadCSVFile(filePath);
+            Assert.AreEqual(expected.Count, actual.Count);
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.AreEqual(expected[i], actual[i]);
+            }
+        }
+    }
+}

--- a/AvailityCSharpAssessment/AvailityCSharpAssessment/Enrollment.cs
+++ b/AvailityCSharpAssessment/AvailityCSharpAssessment/Enrollment.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AvailityCSharpAssessment
+{
+    internal class Enrollment
+    {
+        private string completeString;
+        private string userID;
+        private string firstName;
+        private string lastName;
+        private int version;
+        private string insuranceCompany;
+        private string completeName;
+        private int columnCount;
+
+        /// <summary>
+        /// Class for storing the data read from each line of an enrollment file.
+        /// </summary>
+        /// <param name="enrollmentString">Line from an enrollment file in string format.</param>
+        internal Enrollment(string enrollmentString)
+        {
+            this.CompleteString = enrollmentString;
+            string[] splitLine = enrollmentString.Split(',');
+            this.ColumnCount = splitLine.Length;
+            if(ColumnCount == 5)
+            {
+                this.UserID = splitLine[0];
+                this.FirstName = splitLine[1];
+                this.LastName = splitLine[2];
+                this.Version = Int32.Parse(splitLine[3]);
+                this.InsuranceCompany = splitLine[4];
+                this.CompleteName = splitLine[2] + splitLine[1];
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the complete string.
+        /// </summary>
+        public string CompleteString
+        {
+            get { return completeString; }
+            private set { completeString = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the user ID.
+        /// </summary>
+        public string UserID
+        {
+            get { return userID; }
+            private set { userID = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the first name.
+        /// </summary>
+        public string FirstName
+        {
+            get { return firstName; }
+            private set { firstName = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the last name.
+        /// </summary>
+        public string LastName
+        {
+            get { return lastName; }
+            private set { lastName = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the version.
+        /// </summary>
+        public int Version
+        {
+            get { return version; }
+            private set { version = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the insurance company name.
+        /// </summary>
+        public string InsuranceCompany
+        {
+            get { return insuranceCompany; }
+            private set { insuranceCompany = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the complete name.
+        /// </summary>
+        public string CompleteName
+        {
+            get { return completeName; }
+            private set { completeName = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the column count.
+        /// </summary>
+        public int ColumnCount
+        {
+            get { return columnCount; }
+            private set { columnCount = value; }
+        }
+
+    }
+}

--- a/AvailityCSharpAssessment/AvailityCSharpAssessment/EnrollmentFileFormatter.cs
+++ b/AvailityCSharpAssessment/AvailityCSharpAssessment/EnrollmentFileFormatter.cs
@@ -1,12 +1,56 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AvailityAssessmentTest")]
 
 namespace AvailityCSharpAssessment
 {
-    public static class EnrollmentFileFormatter
+    internal static class EnrollmentFileFormatter
     {
+        /// <summary>
+        /// Takes a path to an enrollment file and checks they type of the file.
+        /// If the file is in csv format, function will format that file.
+        /// </summary>
+        /// <param name="filePath">Path to enrollment file.</param>
+        internal static void FormatEnrollmentFile(string filePath, int expectedColumnCount)
+        {
+            string extension = Path.GetExtension(filePath);
+            if (Path.GetExtension(filePath) == ".csv")
+            {
+                List<string> fileLines = Utilities.ReadCSVFile(filePath);
+                Dictionary<string, List<Enrollment>> separatedByCompany = new Dictionary<string, List<Enrollment>>();
+                // Adding a separate dictionary because I had issues iterating through the first dictionary while
+                // also trying to modify it in place.
+                Dictionary<string, List<Enrollment>> sortedEnrollments = new Dictionary<string, List<Enrollment>>();
+                for(int i = 0; i < fileLines.Count; i++)
+                {
+                    Enrollment enrollment = new Enrollment(fileLines[i]);
+                    // Validate that there is the correct amount of information in the line
+                    if (enrollment.ColumnCount == expectedColumnCount)
+                    {
+                        // If company already exist in dictionary
+                        if (!separatedByCompany.TryAdd(enrollment.InsuranceCompany,
+                            new List<Enrollment>() { enrollment }))
+                        {
+                            separatedByCompany[enrollment.InsuranceCompany].Add(enrollment);
+                        }
+                    }
+                }
+                foreach(KeyValuePair<string, List<Enrollment>> pair in separatedByCompany)
+                {
+                    // Remove duplicate IDs by greatest version number
+                    var temp = separatedByCompany[pair.Key].GroupBy(x => x.UserID).Select(x => x.MaxBy(x => x.Version)).ToList();
+                    // Sort Alphabetically
+                    temp.Sort((x, y) => x.CompleteName.CompareTo(y.CompleteName));
+                    sortedEnrollments.Add(pair.Key, temp);
+                    string stringToWrite = "";
+                    foreach(Enrollment enrollment in sortedEnrollments[pair.Key])
+                    {
+                        stringToWrite = stringToWrite + enrollment.CompleteString + "\n";
+                    }
+                    string newPath = Path.GetFullPath(Path.Combine(filePath, @"..")) + $"\\{pair.Key}.csv";
+                    File.WriteAllText(newPath, stringToWrite);
+                }
+            }
+        }
     }
 }

--- a/AvailityCSharpAssessment/AvailityCSharpAssessment/LISPCodeValidator.cs
+++ b/AvailityCSharpAssessment/AvailityCSharpAssessment/LISPCodeValidator.cs
@@ -17,16 +17,25 @@ namespace AvailityCSharpAssessment
             int openParensCount = 0;
             foreach(char i in lispCode)
             {
-                if (i == '(') openParensCount++;
-                if (i == ')') openParensCount--;
+                if (i == '(')
+                {
+                    openParensCount++;
+                }
+                if (i == ')')
+                {
+                    openParensCount--;
+                }
                 // If too many Closed parentheses are detected, we can return false.
-                if (openParensCount < 0) return false;
+                if (openParensCount < 0)
+                {
+                    return false;
+                }
             }
             // If openParensCount is 0 at the end of the for loop,
             // then all open parentheses have a matching closed parentheses
             // If openParensCount is > 0, then there is a loose open parentheses
             // If openParensCount is < 0, then there is a loose closed parentheses
-            return (openParensCount == 0) ? true : false;
+            return openParensCount == 0;
         }
     }
 }

--- a/AvailityCSharpAssessment/AvailityCSharpAssessment/Program.cs
+++ b/AvailityCSharpAssessment/AvailityCSharpAssessment/Program.cs
@@ -9,6 +9,7 @@
             // String pulled from an example on the Lisp wikipedia page
             string lispCode = "((lambda (arg) (+ arg 1)) 5)";
             LISPCodeValidator.LISPParenthesesChecker(lispCode);
+            EnrollmentFileFormatter.FormatEnrollmentFile(Directory.GetCurrentDirectory() + "\\TestEnrollment_NotEnoughColumns.csv", 5);
         }
     }
 }

--- a/AvailityCSharpAssessment/AvailityCSharpAssessment/Utilities.cs
+++ b/AvailityCSharpAssessment/AvailityCSharpAssessment/Utilities.cs
@@ -1,0 +1,32 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AvailityAssessmentTest")]
+
+namespace AvailityCSharpAssessment
+{
+    internal static class Utilities
+    {
+        /// <summary>
+        /// Reads a CSV file into a list of lines.
+        /// </summary>
+        /// <param name="filePath">Path to CSV file to read.</param>
+        /// <returns>List of lines read from the CSV file.</returns>
+        /// <exception cref="Exception">File Path is invalid.</exception>
+        internal static List<string> ReadCSVFile(string filePath)
+        {
+            // TODO: Potentially benchmark some readline methods
+            List<string> csvLines = new List<string>();
+
+            if (File.Exists(filePath))
+            {
+                foreach (string line in File.ReadAllLines(filePath))
+                {
+                    csvLines.Add(line);
+                }
+            }
+            else throw new Exception("File Path is invalid.");
+
+            return csvLines;
+        }
+    }
+}


### PR DESCRIPTION
Feature that reads and enrollment file. If the file is in csv format, it will read the content of the file, separate enrollees by insurance company, sort the enrollees by last and first name, and remove duplicate user ID's by greatest version number. It will then save the group and sorted information in to a csv file per company.